### PR TITLE
Fix: getMigrationPath() has been removed, use getMigrationPaths() ins…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "robmorgan/phinx": "~0.6",
+        "robmorgan/phinx": "^0.10.6",
         "zendframework/zend-db": ">=2.8",
         "zendframework/zend-servicemanager": "~3.",
         "zendframework/zend-mvc": "~3.",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -28,8 +28,8 @@ return [
 
     'zfphinx' => [
         'paths' => [
-            'migrations' => '',
-            'seeds'      => '',
+            'migrations' => [],
+            'seeds'      => [],
         ],
 
         'environments' => [

--- a/src/ZfPhinx/Command/Test.php
+++ b/src/ZfPhinx/Command/Test.php
@@ -25,7 +25,10 @@ class Test extends TestPrototype
     {
         $this->loadManager($input, $output);
 
-        $this->verifyMigrationDirectory($this->getConfig()->getMigrationPath());
+        $migrationsPaths = (array) $this->getConfig()->getMigrationPaths();
+        foreach ($migrationsPaths as $path) {
+            $this->verifyMigrationDirectory($path);
+        }
 
         $envName = $input->getOption('environment');
         if($envName)


### PR DESCRIPTION
In the latest Phinx (0.10.6) there is no getMigrationPath()-method.  This is a fix for the 'zfphinx test' command.